### PR TITLE
Import 'resolve' from 'path' in vite.config.js to fix 'npm run dev' issue

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import { viteStaticCopy } from "vite-plugin-static-copy";
+import { resolve } from "path";
 
 const cesiumSource = "node_modules/cesium/Build/Cesium";
 // This is the base url for static files that CesiumJS needs to load.


### PR DESCRIPTION
Fix issue related to 'npm run dev' detailed in issue #4